### PR TITLE
COMM-TYRO109F4.config

### DIFF
--- a/configs/default/COMM-TYRO109F4.config
+++ b/configs/default/COMM-TYRO109F4.config
@@ -1,0 +1,137 @@
+# Betaflight / STM32F405 (S405) 4.2.0 Jun 14 2020 / 03:04:22 (8f2d21460) MSP API: 1.43
+
+board_name TYRO109F4
+manufacturer_id COMM
+
+# resources
+resource BEEPER 1 C13
+resource MOTOR 1 C06
+resource MOTOR 2 C07
+resource MOTOR 3 C08
+resource MOTOR 4 C09
+resource MOTOR 5 A15
+resource MOTOR 6 A08
+resource MOTOR 7 B08
+resource PPM 1 A03
+resource PWM 1 A00
+resource PWM 2 A01
+resource PWM 3 A02
+resource LED_STRIP 1 B06
+resource SERIAL_TX 1 A09
+resource SERIAL_TX 2 A02
+resource SERIAL_TX 3 C10
+resource SERIAL_TX 4 A00
+resource SERIAL_TX 5 C12
+resource SERIAL_RX 1 A10
+resource SERIAL_RX 2 A03
+resource SERIAL_RX 3 C11
+resource SERIAL_RX 4 A01
+resource SERIAL_RX 5 D02
+resource I2C_SCL 1 B06
+resource I2C_SDA 1 B07
+resource LED 1 B09
+resource LED 2 A14
+resource SPI_SCK 1 A05
+resource SPI_SCK 2 B13
+resource SPI_SCK 3 B03
+resource SPI_MISO 1 A06
+resource SPI_MISO 2 B14
+resource SPI_MISO 3 B04
+resource SPI_MOSI 1 A07
+resource SPI_MOSI 2 B15
+resource SPI_MOSI 3 B05
+resource ESCSERIAL 1 A03
+resource ADC_BATT 1 C05
+resource ADC_RSSI 1 B01
+resource ADC_CURR 1 C04
+resource SDCARD_CS 1 C01
+resource FLASH_CS 1 C00
+resource OSD_CS 1 B10
+resource GYRO_EXTI 1 C03
+resource GYRO_CS 1 C02
+resource USB_DETECT 1 B12
+
+# timer
+timer A03 AF2
+# pin A03: TIM5 CH4 (AF2)
+timer C06 AF2
+# pin C06: TIM3 CH1 (AF2)
+timer C07 AF3
+# pin C07: TIM8 CH2 (AF3)
+timer C08 AF3
+# pin C08: TIM8 CH3 (AF3)
+timer C09 AF3
+# pin C09: TIM8 CH4 (AF3)
+timer A15 AF1
+# pin A15: TIM2 CH1 (AF1)
+timer A08 AF1
+# pin A08: TIM1 CH1 (AF1)
+timer B08 AF2
+# pin B08: TIM4 CH3 (AF2)
+timer B06 AF2
+# pin B06: TIM4 CH1 (AF2)
+timer A00 AF2
+# pin A00: TIM5 CH1 (AF2)
+timer A01 AF2
+# pin A01: TIM5 CH2 (AF2)
+timer A02 AF3
+# pin A02: TIM9 CH1 (AF3)
+
+# dma
+dma SPI_TX 3 1
+# SPI_TX 3: DMA1 Stream 7 Channel 0
+dma ADC 1 0
+# ADC 1: DMA2 Stream 0 Channel 0
+dma pin A03 0
+# pin A03: DMA1 Stream 1 Channel 6
+dma pin C06 0
+# pin C06: DMA1 Stream 4 Channel 5
+dma pin C07 1
+# pin C07: DMA2 Stream 3 Channel 7
+dma pin C08 1
+# pin C08: DMA2 Stream 4 Channel 7
+dma pin C09 0
+# pin C09: DMA2 Stream 7 Channel 7
+dma pin A15 0
+# pin A15: DMA1 Stream 5 Channel 3
+dma pin A08 0
+# pin A08: DMA2 Stream 6 Channel 0
+dma pin B08 0
+# pin B08: DMA1 Stream 7 Channel 2
+dma pin B06 0
+# pin B06: DMA1 Stream 0 Channel 2
+dma pin A00 0
+# pin A00: DMA1 Stream 2 Channel 6
+dma pin A01 0
+# pin A01: DMA1 Stream 4 Channel 6
+
+# feature
+feature -RX_PARALLEL_PWM
+feature RX_SERIAL
+feature OSD
+
+# serial
+serial 1 64 115200 57600 0 115200
+
+# master
+set mag_bustype = I2C
+set mag_i2c_device = 1
+set baro_bustype = I2C
+set baro_i2c_device = 1
+set blackbox_device = NONE
+set dshot_burst = ON
+set current_meter = ADC
+set battery_meter = ADC
+set ibata_scale = 179
+set beeper_inversion = ON
+set beeper_od = OFF
+set sdcard_mode = SPI
+set sdcard_spi_bus = 3
+set system_hse_mhz = 8
+set max7456_spi_bus = 2
+set dashboard_i2c_bus = 1
+set flash_spi_bus = 3
+set gyro_1_bustype = SPI
+set gyro_1_spibus = 1
+set gyro_1_sensor_align = CW180
+set gyro_1_align_yaw = 1800


### PR DESCRIPTION
Community created config file for Eachine Tyro99/109 FC.
This FC is a clone of / base on MATEKF405.
Specific changes are:

- Gyro yaw alignment: CW180
- Serial based Receiver
- UART2 as Serial RX
- Blackbox logging device set to NONE
